### PR TITLE
Add optional Xquik tweet refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ TWITTER_CLIENT_ID="your-client-id"
 TWITTER_CLIENT_SECRET="your-client-secret"
 TWITTER_BEARER_TOKEN="your-bearer-token"
 
+# Optional Xquik tweet refresh source
+XQUIK_API_KEY="your-xquik-api-key"
+
 # Redis (for job queue)
 REDIS_URL="redis://localhost:6379"                      # Local dev
 # REDIS_URL="redis://default:password@host:port"       # Production (Railway)
@@ -209,6 +212,16 @@ x2ig/
 | `/api/fcm` | POST | Register FCM token for push notifications |
 | `/api/fcm` | DELETE | Unregister FCM token |
 | `/api/health` | GET | Health check endpoint |
+
+### Optional Xquik Tweet Refresh
+
+Set `XQUIK_API_KEY` to let the tweet dashboard hydrate the same local tweet cache from Xquik search for the connected X username:
+
+```bash
+curl "http://localhost:3000/api/tweets?refresh=true&source=xquik&fetchCount=20"
+```
+
+The route calls `GET /api/v1/x/tweets/search` with the `x-api-key` header and a `from:<connected-username>` query. Default refreshes continue to use the existing Twitter/X client unless `source=xquik` is requested.
 
 ## Database Models
 

--- a/src/app/api/tweets/route.ts
+++ b/src/app/api/tweets/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import { fetchUserTweets } from '@/lib/twitter'
+import { fetchXquikUserTweets } from '@/lib/xquik'
 
 export async function GET(request: NextRequest) {
   try {
@@ -22,14 +23,29 @@ export async function GET(request: NextRequest) {
     const page = parseInt(searchParams.get('page') || '1', 10)
     const limit = parseInt(searchParams.get('limit') || '20', 10)
     const fetchCount = parseInt(searchParams.get('fetchCount') || '20', 10) // How many to fetch from Twitter
+    const source = searchParams.get('source') || 'twitter'
 
     // Get user's X user ID and pagination cursor
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
-      select: { xUserId: true, twitterPaginationToken: true },
+      select: { xUserId: true, xUsername: true, twitterPaginationToken: true },
     })
 
-    if (!user?.xUserId) {
+    if (!user) {
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 404 }
+      )
+    }
+
+    if (source === 'xquik' && !user.xUsername) {
+      return NextResponse.json(
+        { error: 'X username not connected' },
+        { status: 400 }
+      )
+    }
+
+    if (source !== 'xquik' && !user.xUserId) {
       return NextResponse.json(
         { error: 'X account not connected' },
         { status: 400 }
@@ -45,13 +61,21 @@ export async function GET(request: NextRequest) {
         // No cursor means we've reached the end — not an error, just no more tweets
         // Fall through to return current DB data with hasMoreOlder: false
       } else {
-        const result = await fetchUserTweets(user.xUserId, Math.min(fetchCount, 100), paginationToken)
+        const xUserId = user.xUserId || ''
+        const result = source === 'xquik'
+          ? {
+              tweets: await fetchXquikUserTweets(user.xUsername || '', Math.min(fetchCount, 100)),
+              nextToken: undefined,
+            }
+          : await fetchUserTweets(xUserId, Math.min(fetchCount, 100), paginationToken)
 
         // Store the pagination cursor for next "load older" call
-        await prisma.user.update({
-          where: { id: session.user.id },
-          data: { twitterPaginationToken: result.nextToken ?? null },
-        })
+        if (source !== 'xquik') {
+          await prisma.user.update({
+            where: { id: session.user.id },
+            data: { twitterPaginationToken: result.nextToken ?? null },
+          })
+        }
 
         // Upsert tweets to database
         for (const tweet of result.tweets) {

--- a/src/lib/xquik.ts
+++ b/src/lib/xquik.ts
@@ -1,0 +1,127 @@
+import type { TweetData } from './twitter'
+
+const XQUIK_API_BASE_URL = process.env.XQUIK_API_BASE_URL ?? 'https://xquik.com'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function stringField(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return ''
+}
+
+function numberField(record: Record<string, unknown> | undefined, keys: string[]): number {
+  if (!record) return 0
+
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value
+    }
+  }
+
+  return 0
+}
+
+function readTweetItems(payload: unknown): Record<string, unknown>[] {
+  if (!isRecord(payload)) {
+    return []
+  }
+
+  const data = payload.data
+  if (Array.isArray(data)) {
+    return data.filter(isRecord)
+  }
+
+  if (isRecord(data)) {
+    if (Array.isArray(data.tweets)) {
+      return data.tweets.filter(isRecord)
+    }
+
+    if (Array.isArray(data.items)) {
+      return data.items.filter(isRecord)
+    }
+  }
+
+  if (Array.isArray(payload.tweets)) {
+    return payload.tweets.filter(isRecord)
+  }
+
+  if (Array.isArray(payload.results)) {
+    return payload.results.filter(isRecord)
+  }
+
+  return []
+}
+
+function mapTweet(tweet: Record<string, unknown>, fallbackUsername: string): TweetData | null {
+  const id = stringField(tweet, ['id', 'tweetId'])
+  const text = stringField(tweet, ['text', 'fullText', 'content'])
+  if (!id || !text) {
+    return null
+  }
+
+  const author = isRecord(tweet.author) ? tweet.author : {}
+  const metrics = isRecord(tweet.public_metrics)
+    ? tweet.public_metrics
+    : isRecord(tweet.metrics)
+      ? tweet.metrics
+      : undefined
+
+  return {
+    id,
+    text,
+    created_at: stringField(tweet, ['createdAt', 'created_at']) || new Date().toISOString(),
+    author: {
+      id: stringField(author, ['id']) || fallbackUsername,
+      name: stringField(author, ['name']) || fallbackUsername,
+      username: stringField(author, ['username', 'screen_name']) || fallbackUsername,
+      profile_image_url: stringField(author, ['profile_image_url', 'profileImageUrl']) || undefined,
+    },
+    public_metrics: {
+      like_count: numberField(metrics, ['like_count', 'likes']),
+      retweet_count: numberField(metrics, ['retweet_count', 'retweets']),
+      reply_count: numberField(metrics, ['reply_count', 'replies']),
+      quote_count: numberField(metrics, ['quote_count', 'quotes']),
+    },
+    media: [],
+  }
+}
+
+export async function fetchXquikUserTweets(
+  username: string,
+  maxTweets: number = 20
+): Promise<TweetData[]> {
+  const apiKey = process.env.XQUIK_API_KEY
+  if (!apiKey || !username.trim()) {
+    return []
+  }
+
+  const cleanUsername = username.trim().replace(/^@/, '')
+  const url = new URL('/api/v1/x/tweets/search', XQUIK_API_BASE_URL)
+  url.searchParams.set('q', `from:${cleanUsername}`)
+  url.searchParams.set('limit', String(Math.min(Math.max(maxTweets, 1), 100)))
+
+  const response = await fetch(url, {
+    headers: {
+      'x-api-key': apiKey,
+    },
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Xquik tweet search failed: ${response.status}`)
+  }
+
+  const payload: unknown = await response.json()
+  return readTweetItems(payload)
+    .map((tweet) => mapTweet(tweet, cleanUsername))
+    .filter((tweet): tweet is TweetData => tweet !== null)
+}


### PR DESCRIPTION
## Summary
- Adds an optional Xquik tweet refresh helper that maps Xquik search results into the existing tweet cache shape.
- Supports `source=xquik` refreshes for the connected X username while keeping default Twitter/X refreshes unchanged.
- Documents the optional `XQUIK_API_KEY` setup and refresh call.

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run lint`
